### PR TITLE
*: Instantiate authority discovery within node/cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,6 +2334,7 @@ dependencies = [
  "srml-system 2.0.0",
  "srml-timestamp 2.0.0",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-authority-discovery 2.0.0",
  "substrate-basic-authorship 2.0.0",
  "substrate-cli 2.0.0",
  "substrate-client 2.0.0",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -46,7 +46,8 @@ system = { package = "srml-system", path = "../../srml/system" }
 balances = { package = "srml-balances", path = "../../srml/balances" }
 support = { package = "srml-support", path = "../../srml/support", default-features = false }
 im_online = { package = "srml-im-online", path = "../../srml/im-online", default-features = false }
-authority-discovery = { package = "srml-authority-discovery", path = "../../srml/authority-discovery", default-features = false }
+sr-authority-discovery = { package = "srml-authority-discovery", path = "../../srml/authority-discovery", default-features = false }
+authority-discovery = { package = "substrate-authority-discovery", path = "../../core/authority-discovery"}
 
 [dev-dependencies]
 keystore = { package = "substrate-keystore", path = "../../core/keystore" }

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -31,7 +31,7 @@ use substrate_service::{
 };
 use transaction_pool::{self, txpool::{Pool as TransactionPool}};
 use inherents::InherentDataProviders;
-use network::construct_simple_protocol;
+use network::{construct_simple_protocol, DhtEvent};
 
 construct_simple_protocol! {
 	/// Demo protocol attachment for substrate.
@@ -103,6 +103,7 @@ macro_rules! new_full_start {
 macro_rules! new_full {
 	($config:expr) => {{
 		use futures::Future;
+		use futures::sync::mpsc;
 
 		let (
 			is_authority,
@@ -118,10 +119,18 @@ macro_rules! new_full {
 
 		let (builder, mut import_setup, inherent_data_providers, mut tasks_to_spawn) = new_full_start!($config);
 
+		// Use bounded channel to ensure back-pressure. Authority discovery consumes this channel. It is triggering one
+		// event per authority within the current authority set. This estimates the authority set size to be somewhere
+		// below 10 000 thereby setting the channel buffer size to 10 000.
+		// TODO: rework comment.
+		let (dht_event_tx, dht_event_rx) =
+			mpsc::channel::<DhtEvent>(10000);
+
 		let service = builder.with_network_protocol(|_| Ok(crate::service::NodeProtocol::new()))?
 			.with_finality_proof_provider(|client, backend|
 				Ok(Arc::new(grandpa::FinalityProofProvider::new(backend, client)) as _)
 			)?
+			.with_dht_event_tx(dht_event_tx)?
 			.build()?;
 
 		let (block_import, link_half, babe_link) = import_setup.take()
@@ -162,6 +171,13 @@ macro_rules! new_full {
 			let babe = babe::start_babe(babe_config)?;
 			let select = babe.select(service.on_exit()).then(|_| Ok(()));
 			service.spawn_task(Box::new(select));
+
+			let authority_discovery = authority_discovery::AuthorityDiscovery::new(
+				service.client(),
+				service.network(),
+				dht_event_rx,
+			);
+			let _ = service.spawn_task(Box::new(authority_discovery));
 		}
 
 		let config = grandpa::Config {


### PR DESCRIPTION
Instead of instantiating the authority discovery module within
core/service, this commit instantiates authority discovery within
node/cli. The authority discovery module depends on the srml authority
discovery module, which depends on the im online module, as well as
session, ...

With the former approach all these dependencies were enforced on any
substrate implementation. With the latter approach these dependencies
are optional.
