### PR TITLE
utils/prometheus/src/lib.rs: Restructure #[cfg] for wasm without hyper

### DIFF
--- a/utils/prometheus/src/lib.rs
+++ b/utils/prometheus/src/lib.rs
@@ -15,13 +15,6 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use futures_util::{FutureExt, future::Future};
-use hyper::http::StatusCode;
-use hyper::{Server, Body, Request, Response, service::{service_fn, make_service_fn}};
-use prometheus::{Encoder, TextEncoder, core::Collector};
-use std::net::SocketAddr;
-#[cfg(not(target_os = "unknown"))]
-mod networking;
-
 pub use prometheus::{
 	Registry, Error as PrometheusError, Opts,
 	core::{
@@ -30,100 +23,122 @@ pub use prometheus::{
 		AtomicF64 as F64, AtomicI64 as I64, AtomicU64 as U64,
 	}
 };
+use prometheus::{Encoder, TextEncoder, core::Collector};
+use std::net::SocketAddr;
+
+#[cfg(target_os = "unknown")]
+pub use unknown_os::init_prometheus;
+
+#[cfg(not(target_os = "unknown"))]
+mod networking;
+pub use known_os::init_prometheus;
+
 
 pub fn register<T: Clone + Collector + 'static>(metric: T, registry: &Registry) -> Result<T, PrometheusError> {
 	registry.register(Box::new(metric.clone()))?;
 	Ok(metric)
 }
 
-#[derive(Debug, derive_more::Display, derive_more::From)]
-pub enum Error {
-	/// Hyper internal error.
-	Hyper(hyper::Error),
-	/// Http request error.
-	Http(hyper::http::Error),
-	/// i/o error.
-	Io(std::io::Error),
-	#[display(fmt = "Prometheus exporter port {} already in use.", _0)]
-	PortInUse(SocketAddr)
-}
+// On WASM `init_prometheus` becomes a no-op.
+#[cfg(target_os = "unknown")]
+mod unknown_os {
+	use super::*;
 
-impl std::error::Error for Error {
-	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-		match self {
-			Error::Hyper(error) => Some(error),
-			Error::Http(error) => Some(error),
-			Error::Io(error) => Some(error),
-			Error::PortInUse(_) => None
-		}
+	pub enum Error {}
+
+	pub async fn init_prometheus(_: SocketAddr, _registry: Registry) -> Result<(), Error> {
+		Ok(())
 	}
 }
-
-async fn request_metrics(req: Request<Body>, registry: Registry) -> Result<Response<Body>, Error> {
-	if req.uri().path() == "/metrics" {
-		let metric_families = registry.gather();
-		let mut buffer = vec![];
-		let encoder = TextEncoder::new();
-		encoder.encode(&metric_families, &mut buffer).unwrap();
-
-		Response::builder().status(StatusCode::OK)
-			.header("Content-Type", encoder.format_type())
-			.body(Body::from(buffer))
-			.map_err(Error::Http)
-	} else {
-		Response::builder().status(StatusCode::NOT_FOUND)
-		.body(Body::from("Not found."))
-		.map_err(Error::Http)
-	}
-
-}
-
-#[derive(Clone)]
-pub struct Executor;
 
 #[cfg(not(target_os = "unknown"))]
-impl<T> hyper::rt::Executor<T> for Executor
+mod known_os {
+	use super::*;
+	use hyper::http::StatusCode;
+	use hyper::{Server, Body, Request, Response, service::{service_fn, make_service_fn}};
+
+	#[derive(Debug, derive_more::Display, derive_more::From)]
+	pub enum Error {
+		/// Hyper internal error.
+		Hyper(hyper::Error),
+		/// Http request error.
+		Http(hyper::http::Error),
+		/// i/o error.
+		Io(std::io::Error),
+		#[display(fmt = "Prometheus exporter port {} already in use.", _0)]
+		PortInUse(SocketAddr)
+	}
+
+	impl std::error::Error for Error {
+		fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+			match self {
+				Error::Hyper(error) => Some(error),
+				Error::Http(error) => Some(error),
+				Error::Io(error) => Some(error),
+				Error::PortInUse(_) => None
+			}
+		}
+	}
+
+	async fn request_metrics(req: Request<Body>, registry: Registry) -> Result<Response<Body>, Error> {
+		if req.uri().path() == "/metrics" {
+			let metric_families = registry.gather();
+			let mut buffer = vec![];
+			let encoder = TextEncoder::new();
+			encoder.encode(&metric_families, &mut buffer).unwrap();
+
+			Response::builder().status(StatusCode::OK)
+				.header("Content-Type", encoder.format_type())
+				.body(Body::from(buffer))
+				.map_err(Error::Http)
+		} else {
+			Response::builder().status(StatusCode::NOT_FOUND)
+				.body(Body::from("Not found."))
+				.map_err(Error::Http)
+		}
+
+	}
+
+	#[derive(Clone)]
+	pub struct Executor;
+
+	impl<T> hyper::rt::Executor<T> for Executor
 	where
 		T: Future + Send + 'static,
 		T::Output: Send + 'static,
-{
-	fn execute(&self, future: T) {
-		async_std::task::spawn(future);
-	}
-}
-
-/// Initializes the metrics context, and starts an HTTP server
-/// to serve metrics.
-#[cfg(not(target_os = "unknown"))]
-pub async fn init_prometheus(prometheus_addr: SocketAddr, registry: Registry) -> Result<(), Error>{
-	use networking::Incoming;
-	let listener = async_std::net::TcpListener::bind(&prometheus_addr)
-		.await
-		.map_err(|_| Error::PortInUse(prometheus_addr))?;
-
-	log::info!("Prometheus server started at {}", prometheus_addr);
-
-	let service = make_service_fn(move |_| {
-		let registry = registry.clone();
-
-		async move {
-			Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
-				request_metrics(req, registry.clone())
-			}))
+	{
+		fn execute(&self, future: T) {
+			async_std::task::spawn(future);
 		}
-	});
+	}
 
-	let server = Server::builder(Incoming(listener.incoming()))
-		.executor(Executor)
-		.serve(service)
-		.boxed();
+	/// Initializes the metrics context, and starts an HTTP server
+	/// to serve metrics.
+	pub async fn init_prometheus(prometheus_addr: SocketAddr, registry: Registry) -> Result<(), Error>{
+		use networking::Incoming;
+		let listener = async_std::net::TcpListener::bind(&prometheus_addr)
+			.await
+			.map_err(|_| Error::PortInUse(prometheus_addr))?;
 
-	let result = server.await.map_err(Into::into);
+		log::info!("Prometheus server started at {}", prometheus_addr);
 
-	result
-}
+		let service = make_service_fn(move |_| {
+			let registry = registry.clone();
 
-#[cfg(target_os = "unknown")]
-pub async fn init_prometheus(_: SocketAddr, _registry: Registry) -> Result<(), Error> {
-	Ok(())
+			async move {
+				Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
+					request_metrics(req, registry.clone())
+				}))
+			}
+		});
+
+		let server = Server::builder(Incoming(listener.incoming()))
+			.executor(Executor)
+			.serve(service)
+			.boxed();
+
+		let result = server.await.map_err(Into::into);
+
+		result
+	}
 }


### PR DESCRIPTION
Given that Hyper is not compatible with WASM targets it needs to be
excluded from WASM builds. Instead of introducing #[cfg] lines
throughout the crate, this patch splits the crate into two: known_os and
unknown_os (WASM).